### PR TITLE
Remove web target configuration to resolve compatibility issues and streamline the mobile development workflow

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,11 +19,6 @@
       },
       "package": "com.anonymous.abstraxionexpodemo"
     },
-    "web": {
-      "bundler": "metro",
-      "output": "static",
-      "favicon": "./assets/images/favicon.png"
-    },
     "plugins": [
       "expo-router",
       [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "reset-project": "node ./scripts/reset-project.js",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web",
     "test": "jest --watchAll",
     "lint": "expo lint"
   },
@@ -44,7 +43,6 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
-    "react-native-web": "^0.20.0",
     "react-native-webview": "13.13.5"
   },
   "devDependencies": {


### PR DESCRIPTION
The web target in this Expo project has been causing several issues:

  1. **Build errors**: Metro bundler configuration conflicts when trying to support both web and native platforms
  2. **Dependency conflicts**: react-native-web creates compatibility issues with native-specific modules like:
     - react-native-quick-crypto
     - react-native-libsodium
     - react-native-webview
  3. **Maintenance overhead**: Supporting web requires additional testing and configuration that isn't needed for this mobile-focused application

### Changes made
  - Removed `web` configuration section from app.json
  - Removed `react-native-web` dependency from package.json and the `web` script